### PR TITLE
feat: add Translate link for text pastes via translation-inference

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -164,6 +164,9 @@ pub struct Args {
         default_value_t = 2048
     )]
     pub max_file_size_unencrypted_mb: usize,
+
+    #[clap(long, env = "BITVAULT_TRANSLATE_URL")]
+    pub translate_url: Option<String>,
 }
 
 impl Args {
@@ -230,7 +233,16 @@ impl Args {
             encryption_server_side: self.encryption_server_side,
             max_file_size_encrypted_mb: self.max_file_size_encrypted_mb,
             max_file_size_unencrypted_mb: self.max_file_size_unencrypted_mb,
+            translate_url: self.translate_url.clone(),
         }
+    }
+
+    pub fn translate_url_as_str(&self) -> String {
+        self.translate_url
+            .as_deref()
+            .unwrap_or("")
+            .trim_end_matches('/')
+            .to_string()
     }
 
     pub fn max_expiry_index(&self) -> usize {

--- a/src/args.rs
+++ b/src/args.rs
@@ -233,7 +233,7 @@ impl Args {
             encryption_server_side: self.encryption_server_side,
             max_file_size_encrypted_mb: self.max_file_size_encrypted_mb,
             max_file_size_unencrypted_mb: self.max_file_size_unencrypted_mb,
-            translate_url: self.translate_url.clone(),
+            translate_url: self.translate_url,
         }
     }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -241,6 +241,7 @@ impl Args {
         self.translate_url
             .as_deref()
             .unwrap_or("")
+            .trim()
             .trim_end_matches('/')
             .to_string()
     }

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -32,8 +32,8 @@
     Copy URL
   </button>
   {%- endif %}
-  {% if args.translate_url_as_str() != "" && pasta.content != "" && pasta.pasta_type != "url" && !pasta.encrypt_client %}
-  <a style="margin-left: 0.5rem" href="{{ args.translate_url_as_str() }}?from={{ args.public_path_as_str() }}/raw/{{pasta.id_as_words()}}">Translate</a>
+  {% if args.translate_url_as_str() != "" && args.public_path_as_str() != "" && pasta.content != "" && pasta.pasta_type != "url" && !pasta.encrypt_client && !pasta.encrypt_server %}
+  <a style="margin-left: 0.5rem" href="{{ args.translate_url_as_str() }}?from={{ (args.public_path_as_str() ~ "/raw/" ~ pasta.id_as_words()) | urlencode }}">Translate</a>
   {%- endif %}
 </div>
 

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -32,6 +32,9 @@
     Copy URL
   </button>
   {%- endif %}
+  {% if args.translate_url_as_str() != "" && pasta.content != "" && pasta.pasta_type != "url" && !pasta.encrypt_client %}
+  <a style="margin-left: 0.5rem" href="{{ args.translate_url_as_str() }}?from={{ args.public_path_as_str() }}/raw/{{pasta.id_as_words()}}">Translate</a>
+  {%- endif %}
 </div>
 
 <br>


### PR DESCRIPTION
## Summary

Adds a **Translate** link to the paste view page when `BITVAULT_TRANSLATE_URL` is configured. Clicking the link opens the configured translation-inference instance with the paste's raw content pre-loaded and auto-translated.

### New env var / CLI flag

| Var | Flag | Description |
|---|---|---|
| `BITVAULT_TRANSLATE_URL` | `--translate-url` | Base URL of the translation-inference instance |

### Behaviour

- The link appears in the top-right of the paste view, next to Copy URL.
- It links to `{BITVAULT_TRANSLATE_URL}?from={PUBLIC_PATH}/raw/{paste-id}`.
- Suppressed for URL-type pastes, client-encrypted pastes, and when `BITVAULT_TRANSLATE_URL` is unset.
- The translation-inference side fetches the raw content server-side (no CORS issue) and auto-triggers translation on load.

## Test plan

- [ ] Without `BITVAULT_TRANSLATE_URL`: no Translate link visible anywhere
- [ ] With `BITVAULT_TRANSLATE_URL` set: Translate link appears on text pastes
- [ ] Translate link absent on URL-type pastes
- [ ] Translate link absent on client-encrypted (`secret`) pastes
- [ ] Clicking Translate opens translation-inference with content pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)